### PR TITLE
Add dropoutRate as a parameter

### DIFF
--- a/ENet.py
+++ b/ENet.py
@@ -195,23 +195,23 @@ class ENet(nn.Module):
                                                    BottleNeck(K * 4, K * 4, F))
                 self.bottleneck2_0 = BottleNeckDownSampling(K * 4, K * 8, F)
                 self.bottleneck2_1 = nn.Sequential(BottleNeck(K * 8, K * 8, F, dropoutRate=0.1),
-                                                   BottleNeck(K * 8, K * 8, F, dilation=2),
+                                                   BottleNeck(K * 8, K * 8, F, dilation=2, dropoutRate=0.1),
                                                    BottleNeck(K * 8, K * 8, F, dropoutRate=0.1, asym=True),
-                                                   BottleNeck(K * 8, K * 8, F, dilation=4),
+                                                   BottleNeck(K * 8, K * 8, F, dilation=4, dropoutRate=0.1),
                                                    BottleNeck(K * 8, K * 8, F, dropoutRate=0.1),
-                                                   BottleNeck(K * 8, K * 8, F, dilation=8),
+                                                   BottleNeck(K * 8, K * 8, F, dilation=8, dropoutRate=0.1),
                                                    BottleNeck(K * 8, K * 8, F, dropoutRate=0.1, asym=True),
-                                                   BottleNeck(K * 8, K * 8, F, dilation=16))
+                                                   BottleNeck(K * 8, K * 8, F, dilation=16, dropoutRate=0.1))
 
                 # Middle operations
                 self.bottleneck3 = nn.Sequential(BottleNeck(K * 8, K * 8, F, dropoutRate=0.1),
-                                                 BottleNeck(K * 8, K * 8, F, dilation=2),
+                                                 BottleNeck(K * 8, K * 8, F, dilation=2, dropoutRate=0.1),
                                                  BottleNeck(K * 8, K * 8, F, dropoutRate=0.1, asym=True),
-                                                 BottleNeck(K * 8, K * 8, F, dilation=4),
+                                                 BottleNeck(K * 8, K * 8, F, dilation=4, dropoutRate=0.1),
                                                  BottleNeck(K * 8, K * 8, F, dropoutRate=0.1),
-                                                 BottleNeck(K * 8, K * 8, F, dilation=8),
+                                                 BottleNeck(K * 8, K * 8, F, dilation=8, dropoutRate=0.1),
                                                  BottleNeck(K * 8, K * 8, F, dropoutRate=0.1, asym=True),
-                                                 BottleNeck(K * 8, K * 4, F, dilation=16, dilate_last=True))
+                                                 BottleNeck(K * 8, K * 4, F, dilation=16, dilate_last=True, dropoutRate=0.1))
 
                 # Upsampling half
                 self.bottleneck4 = nn.Sequential(BottleNeckUpSampling(K * 8, K * 4, F),

--- a/ENet.py
+++ b/ENet.py
@@ -136,7 +136,8 @@ class BottleNeckDownSampling(nn.Module):
 
 
 class BottleNeckUpSampling(nn.Module):
-        def __init__(self, in_dim, out_dim, projectionFactor):
+        def __init__(self, in_dim, out_dim, projectionFactor,
+                     dropoutRate=0.01):
                 super().__init__()
                 mid_dim: int = in_dim // projectionFactor
 
@@ -149,7 +150,7 @@ class BottleNeckUpSampling(nn.Module):
                 self.block2 = conv_block(mid_dim, out_dim, kernel_size=1)
 
                 # Regularizer
-                self.do = nn.Dropout(p=0.01)
+                self.do = nn.Dropout(p=dropoutRate)
                 self.PReLU = nn.PReLU()
 
                 # Out
@@ -177,6 +178,7 @@ class ENet(nn.Module):
                 super().__init__()
                 F: int = kwargs["factor"] if "factor" in kwargs else 4  # Projecting factor
                 K: int = kwargs["kernels"] if "kernels" in kwargs else 16  # n_kernels
+                dr: float = kwargs["dropoutRate"] if "dropoutRate" in kwargs else 0.1
 
                 # from models.enet import (BottleNeck,
                 #                          BottleNeckDownSampling,
@@ -194,31 +196,31 @@ class ENet(nn.Module):
                                                    BottleNeck(K * 4, K * 4, F),
                                                    BottleNeck(K * 4, K * 4, F))
                 self.bottleneck2_0 = BottleNeckDownSampling(K * 4, K * 8, F)
-                self.bottleneck2_1 = nn.Sequential(BottleNeck(K * 8, K * 8, F, dropoutRate=0.1),
-                                                   BottleNeck(K * 8, K * 8, F, dilation=2, dropoutRate=0.1),
-                                                   BottleNeck(K * 8, K * 8, F, dropoutRate=0.1, asym=True),
-                                                   BottleNeck(K * 8, K * 8, F, dilation=4, dropoutRate=0.1),
-                                                   BottleNeck(K * 8, K * 8, F, dropoutRate=0.1),
-                                                   BottleNeck(K * 8, K * 8, F, dilation=8, dropoutRate=0.1),
-                                                   BottleNeck(K * 8, K * 8, F, dropoutRate=0.1, asym=True),
-                                                   BottleNeck(K * 8, K * 8, F, dilation=16, dropoutRate=0.1))
+                self.bottleneck2_1 = nn.Sequential(BottleNeck(K * 8, K * 8, F, dropoutRate=dr),
+                                                   BottleNeck(K * 8, K * 8, F, dilation=2, dropoutRate=dr),
+                                                   BottleNeck(K * 8, K * 8, F, dropoutRate=dr, asym=True),
+                                                   BottleNeck(K * 8, K * 8, F, dilation=4, dropoutRate=dr),
+                                                   BottleNeck(K * 8, K * 8, F, dropoutRate=dr),
+                                                   BottleNeck(K * 8, K * 8, F, dilation=8, dropoutRate=dr),
+                                                   BottleNeck(K * 8, K * 8, F, dropoutRate=dr, asym=True),
+                                                   BottleNeck(K * 8, K * 8, F, dilation=16, dropoutRate=dr))
 
                 # Middle operations
-                self.bottleneck3 = nn.Sequential(BottleNeck(K * 8, K * 8, F, dropoutRate=0.1),
-                                                 BottleNeck(K * 8, K * 8, F, dilation=2, dropoutRate=0.1),
-                                                 BottleNeck(K * 8, K * 8, F, dropoutRate=0.1, asym=True),
-                                                 BottleNeck(K * 8, K * 8, F, dilation=4, dropoutRate=0.1),
-                                                 BottleNeck(K * 8, K * 8, F, dropoutRate=0.1),
-                                                 BottleNeck(K * 8, K * 8, F, dilation=8, dropoutRate=0.1),
-                                                 BottleNeck(K * 8, K * 8, F, dropoutRate=0.1, asym=True),
-                                                 BottleNeck(K * 8, K * 4, F, dilation=16, dilate_last=True, dropoutRate=0.1))
+                self.bottleneck3 = nn.Sequential(BottleNeck(K * 8, K * 8, F, dropoutRate=dr),
+                                                 BottleNeck(K * 8, K * 8, F, dilation=2, dropoutRate=dr),
+                                                 BottleNeck(K * 8, K * 8, F, dropoutRate=dr, asym=True),
+                                                 BottleNeck(K * 8, K * 8, F, dilation=4, dropoutRate=dr),
+                                                 BottleNeck(K * 8, K * 8, F, dropoutRate=dr),
+                                                 BottleNeck(K * 8, K * 8, F, dilation=8, dropoutRate=dr),
+                                                 BottleNeck(K * 8, K * 8, F, dropoutRate=dr, asym=True),
+                                                 BottleNeck(K * 8, K * 4, F, dilation=16, dilate_last=True, dropoutRate=dr))
 
                 # Upsampling half
-                self.bottleneck4 = nn.Sequential(BottleNeckUpSampling(K * 8, K * 4, F),
-                                                 BottleNeck(K * 4, K * 4, F, dropoutRate=0.1),
-                                                 BottleNeck(K * 4, K, F, dropoutRate=0.1))
-                self.bottleneck5 = nn.Sequential(BottleNeckUpSampling(K * 2, K, F),
-                                                 BottleNeck(K, K, F, dropoutRate=0.1))
+                self.bottleneck4 = nn.Sequential(BottleNeckUpSampling(K * 8, K * 4, F, dropoutRate=dr),
+                                                 BottleNeck(K * 4, K * 4, F, dropoutRate=dr),
+                                                 BottleNeck(K * 4, K, F, dropoutRate=dr))
+                self.bottleneck5 = nn.Sequential(BottleNeckUpSampling(K * 2, K, F, dropoutRate=dr),
+                                                 BottleNeck(K, K, F, dropoutRate=dr))
 
                 # Final upsampling and covolutions
                 self.final = nn.Sequential(conv_block(K, K, kernel_size=3, padding=1, bias=False, stride=1),

--- a/main.py
+++ b/main.py
@@ -150,6 +150,7 @@ def runTraining(args):
     log_dice_val: Tensor = torch.zeros((args.epochs, len(val_loader.dataset), K))
 
     best_dice: float = 0
+    best_metrics = {}
 
     for e in range(args.epochs):
         for m in ['train', 'val']:
@@ -236,8 +237,10 @@ def runTraining(args):
 
             torch.save(net, args.dest / "bestmodel.pkl")
             torch.save(net.state_dict(), args.dest / "bestweights.pt")
-            wandb.run.summary = metrics
+            best_metrics = metrics
 
+    for key, value in best_metrics.items():
+        wandb.run.summary[key] = value
     end = time.time()
     print(f"[FINISHED] Duration: {(end - start):0.2f} s")
 

--- a/main.py
+++ b/main.py
@@ -72,7 +72,7 @@ def setup(args) -> tuple[nn.Module, Any, Any, DataLoader, DataLoader, int]:
 
     K: int = datasets_params[args.dataset]['K']
     try:
-        net = eval(args.model)(1, K, {'dropoutRate': args.dropoutRate})
+        net = eval(args.model)(1, K, dropoutRate=args.dropoutRate)
     except NameError:
         raise ValueError(f"Model {args.model} does not exist")
     net.init_weights()


### PR DESCRIPTION
According to the original ENet paper, all layers higher than layer bottleneck2.0 have a dropout of 0.1.
This has been configured in the code, along with a variable dropoutRate that can be passed as an argument.