### PR TITLE
Fix save dir for parallel runs

### DIFF
--- a/jobs/run_template.job
+++ b/jobs/run_template.job
@@ -19,4 +19,4 @@ source activate ai4mi
 
 # Go to the directory that contains the project, the runnable
 cd $HOME/ai4mi_project
-srun python -O main.py --gpu --dataset SEGTHOR --dest results/segthor/ce
+srun python -O main.py --gpu --dataset SEGTHOR --dest results/segthor

--- a/main.py
+++ b/main.py
@@ -249,7 +249,7 @@ def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument('--epochs', default=200, type=int)
-    parser.add_argument('--dataset', default='TOY2', choices=datasets_params.keys())
+    parser.add_argument('--dataset', default='SEGTHOR', choices=datasets_params.keys())
     parser.add_argument('--mode', default='full', choices=['partial', 'full'])
     parser.add_argument('--args', default='')
     parser.add_argument('--dest', type=Path, required=True,
@@ -281,6 +281,7 @@ def main():
     prefix = args.run_prefix + '_' if args.run_prefix else ''
     run_name = f'{prefix}{args.loss}_{args.model}_{args.dataset[:3]}'
     run_name = 'DEBUG_' + run_name if args.debug else run_name
+    args.dest = args.dest / run_name
 
     # Added since for python 3.8+, OS X multiprocessing starts processes with spawn instead of fork
     # see https://github.com/pytest-dev/pytest-flask/issues/104


### PR DESCRIPTION
Parallel runs would block on the write key for the same save directory.
- Specific save folders would be created from the `run_name` var
- If existent, it will be overwritten