### PR TITLE
Add new segmentation models

### DIFF
--- a/ShallowNet.py
+++ b/ShallowNet.py
@@ -34,7 +34,8 @@ def convBatch(nin, nout, kernel_size=3, stride=1, padding=1, bias=False, layer=n
 
 
 class shallowCNN(nn.Module):
-    def __init__(self, nin, nout, nG=4):
+    def __init__(self, nin, nout, **kwargs):
+        nG: int = 4
         super(shallowCNN, self).__init__()
         self.conv0 = convBatch(nin, nG * 4)
         self.conv1 = convBatch(nG * 4, nG * 4)

--- a/environment.yaml
+++ b/environment.yaml
@@ -16,3 +16,4 @@ dependencies:
     - scikit-image
     - matplotlib
     - wandb # will have to remove this at final submission time
+    - segmentation-models-pytorch

--- a/jobs/array_run_template.job
+++ b/jobs/array_run_template.job
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+#SBATCH --array=1-3
+#SBATCH --partition=gpu
+#SBATCH --gpus=1
+#SBATCH --job-name=LR_scheduler
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=18
+#SBATCH --time=04:00:00
+#SBATCH --output=/home/scur2504/output/success/out-%x.%A.out
+#SBATCH --error=/home/scur2504/output/error/out-%x.%A.err
+
+module purge
+# The default modules for deep learning
+module load 2022
+module load Anaconda3/2022.05
+
+# Activate your environment
+source activate ai4mi
+
+# Go to the directory that contains the project, the runnable
+# Your job starts in the directory where you call sbatch
+cd $HOME/ai4mi_project
+
+# Read line by line (per job in array) from the config file
+CONFIG_FILE=$HOME/config_array_job.txt
+PARAMS=$( sed -n ${SLURM_ARRAY_TASK_ID}p $CONFIG_FILE )
+
+echo $PARAMS
+
+# Run your code
+srun python -O main.py --gpu --dataset SEGTHOR --dest results/segthor --dry_run $PARAMS

--- a/jobs/config_array_job.txt
+++ b/jobs/config_array_job.txt
@@ -1,0 +1,5 @@
+--model ENet --lr 0.0005 --lr_scheduler_T0 10 --lr_scheduler_Tmult 1
+--model ENet --lr 0.0005 --lr_scheduler_T0 10 --lr_scheduler_Tmult 2
+--model ENet --lr 0.0005 --lr_scheduler_T0 20 --lr_scheduler_Tmult 1
+--model ENet --lr 0.0005 --lr_scheduler_T0 20 --lr_scheduler_Tmult 2
+--model ENet --dropoutRate 0.1 --lr 0.0005 --lr_scheduler_T0 10 --lr_scheduler_Tmult 2

--- a/jobs/run_template.job
+++ b/jobs/run_template.job
@@ -19,4 +19,4 @@ source activate ai4mi
 
 # Go to the directory that contains the project, the runnable
 cd $HOME/ai4mi_project
-srun python -O main.py --gpu --dataset SEGTHOR --dest results/segthor/ce
+srun python -O main.py --gpu --dataset SEGTHOR --dest results/segthor

--- a/main.py
+++ b/main.py
@@ -78,7 +78,7 @@ def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, torch.optim.lr_schedu
 
     # lr = 0.0005 # Initial LR for ENet
     lr = args.lr
-    optimizer = torch.optim.AdamW(net.parameters(), lr=lr, betas=(0.9, 0.999))
+    optimizer = torch.optim.AdamW(net.parameters(), lr=lr, betas=(0.9, 0.999), weight_decay=args.lr_weight_decay)
     scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=args.lr_scheduler_T0, T_mult=args.lr_scheduler_Tmult)
 
     # Dataset part
@@ -272,6 +272,7 @@ def main():
     parser.add_argument('--lr', type=float, default=0.0005, help="Learning rate")
     parser.add_argument('--lr_scheduler_T0', type=int, default=10, help="T0 for the LR scheduler")
     parser.add_argument('--lr_scheduler_Tmult', type=int, default=2, help="Tmult for the LR scheduler")
+    parser.add_argument('--lr_weight_decay', type=float, default=0.01, help="Weight decay factor for the AdamW optimizer")
 
     parser.add_argument('--alpha', type=float, default=0.5, help="Alpha parameter for loss functions")
     parser.add_argument('--beta', type=float, default=0.5, help="Beta parameter for loss functions")

--- a/main.py
+++ b/main.py
@@ -76,11 +76,6 @@ def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, torch.optim.lr_schedu
     net.init_weights()
     net.to(device)
 
-    # lr = 0.0005 # Initial LR for ENet
-    lr = args.lr
-    optimizer = torch.optim.AdamW(net.parameters(), lr=lr, betas=(0.9, 0.999), weight_decay=args.lr_weight_decay)
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=args.lr_scheduler_T0, T_mult=args.lr_scheduler_Tmult)
-
     # Dataset part
     B: int = datasets_params[args.dataset]['B']
     if args.scratch:
@@ -132,6 +127,11 @@ def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, torch.optim.lr_schedu
                             shuffle=False)
 
     args.dest.mkdir(parents=True, exist_ok=True)
+
+    # lr = 0.0005 # Initial LR for ENet
+    lr = args.lr
+    optimizer = torch.optim.AdamW(net.parameters(), lr=lr, betas=(0.9, 0.999), weight_decay=args.lr_weight_decay)
+    scheduler = torch.optim.lr_scheduler.OneCycleLR(optimizer, lr, epochs=args.epochs, steps_per_epoch=len(train_loader))
 
     return net, optimizer, scheduler, device, train_loader, val_loader, K
 
@@ -272,8 +272,6 @@ def main():
 
     parser.add_argument('--dropoutRate', type=float, default=0.2, help="Dropout rate for the ENet model")
     parser.add_argument('--lr', type=float, default=0.0005, help="Learning rate")
-    parser.add_argument('--lr_scheduler_T0', type=int, default=10, help="T0 for the LR scheduler")
-    parser.add_argument('--lr_scheduler_Tmult', type=int, default=2, help="Tmult for the LR scheduler")
     parser.add_argument('--lr_weight_decay', type=float, default=0.01, help="Weight decay factor for the AdamW optimizer")
 
     parser.add_argument('--alpha', type=float, default=0.5, help="Alpha parameter for loss functions")

--- a/main.py
+++ b/main.py
@@ -248,7 +248,7 @@ def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument('--epochs', default=200, type=int)
-    parser.add_argument('--dataset', default='TOY2', choices=datasets_params.keys())
+    parser.add_argument('--dataset', default='SEGTHOR', choices=datasets_params.keys())
     parser.add_argument('--mode', default='full', choices=['partial', 'full'])
     parser.add_argument('--args', default='')
     parser.add_argument('--dest', type=Path, required=True,
@@ -279,8 +279,9 @@ def main():
 
     args = parser.parse_args()
     prefix = args.run_prefix + '_' if args.run_prefix else ''
-    run_name = f'{prefix}{args.loss}_{args.model}_{args.dataset[:3]}'
+    run_name = f'{prefix}lr({"{:.0E}".format(args.lr)})_{args.loss}_{args.model}'
     run_name = 'DEBUG_' + run_name if args.debug else run_name
+    args.dest = args.dest / run_name
 
     # Added since for python 3.8+, OS X multiprocessing starts processes with spawn instead of fork
     # see https://github.com/pytest-dev/pytest-flask/issues/104

--- a/main.py
+++ b/main.py
@@ -272,8 +272,7 @@ def main():
     parser.add_argument('--lr_scheduler_T0', type=int, default=10, help="T0 for the LR scheduler")
     parser.add_argument('--lr_scheduler_Tmult', type=int, default=2, help="Tmult for the LR scheduler")
 
-
-    parser.add_argument('--dropoutRate', type=float, default=0.1, help="Dropout rate for the ENet model")
+    parser.add_argument('--dropoutRate', type=float, default=0.2, help="Dropout rate for the ENet model")
     parser.add_argument('--alpha', type=float, default=0.5, help="Alpha parameter for loss functions")
     parser.add_argument('--beta', type=float, default=0.5, help="Beta parameter for loss functions")
     parser.add_argument('--focal_alpha', type=float, default=0.25, help="Alpha parameter for Focal Loss")

--- a/main.py
+++ b/main.py
@@ -65,8 +65,7 @@ datasets_params["TOY2"] = {'K': 2, 'net': shallowCNN, 'B': 2}
 datasets_params["SEGTHOR"] = {'K': 5, 'net': ENet, 'B': 8}
 
 
-# def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, torch.optim.lr_scheduler.LRScheduler, Any, DataLoader, DataLoader, int]:
-def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, Any, DataLoader, DataLoader, int]:
+def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, torch.optim.lr_scheduler.LRScheduler, Any, DataLoader, DataLoader, int]:
     # Networks and scheduler
     gpu: bool = args.gpu and torch.cuda.is_available()
     device = torch.device("cuda") if gpu else torch.device("cpu")
@@ -80,7 +79,7 @@ def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, Any, DataLoader, Data
     # lr = 0.0005 # Initial LR for ENet
     lr = args.lr
     optimizer = torch.optim.AdamW(net.parameters(), lr=lr, betas=(0.9, 0.999), weight_decay=args.lr_weight_decay)
-    # scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=args.lr_scheduler_T0, T_mult=args.lr_scheduler_Tmult)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=args.lr_scheduler_T0, T_mult=args.lr_scheduler_Tmult)
 
     # Dataset part
     B: int = datasets_params[args.dataset]['B']
@@ -134,8 +133,7 @@ def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, Any, DataLoader, Data
 
     args.dest.mkdir(parents=True, exist_ok=True)
 
-    # return net, optimizer, scheduler, device, train_loader, val_loader, K
-    return net, optimizer, device, train_loader, val_loader, K
+    return net, optimizer, scheduler, device, train_loader, val_loader, K
 
 
 def runTraining(args):
@@ -143,8 +141,7 @@ def runTraining(args):
     utils.seed_everything(args)
     start = time.time()
     print(f">>> Setting up to train on {args.dataset} with {args.model}")
-    # net, optimizer, scheduler, device, train_loader, val_loader, K = setup(args)
-    net, optimizer, device, train_loader, val_loader, K = setup(args)
+    net, optimizer, scheduler, device, train_loader, val_loader, K = setup(args)
 
     loss_fn = create_loss_fn(args, K)
 
@@ -225,7 +222,7 @@ def runTraining(args):
 
         # Apply LR scheduler
         before_lr = optimizer.param_groups[0]['lr']
-        # scheduler.step()
+        scheduler.step()
         after_lr = optimizer.param_groups[0]['lr']
         print("Epoch %d: AdamW lr %.3E -> %.3E" % (e, before_lr, after_lr))
 

--- a/main.py
+++ b/main.py
@@ -199,7 +199,7 @@ def runTraining(args):
                         loss.backward()
                         opt.step()
 
-                    if m == 'val':
+                    if m == 'val' and not args.dry_run:
                         with warnings.catch_warnings():
                             warnings.filterwarnings('ignore', category=UserWarning)
                             predicted_class: Tensor = probs2class(pred_probs)
@@ -229,10 +229,11 @@ def runTraining(args):
             with open(args.dest / "best_epoch.txt", 'w') as f:
                     f.write(str(e))
 
-            best_folder = args.dest / "best_epoch"
-            if best_folder.exists():
-                    rmtree(best_folder)
-            copytree(args.dest / f"iter{e:03d}", Path(best_folder))
+            if not args.dry_run:
+                best_folder = args.dest / "best_epoch"
+                if best_folder.exists():
+                        rmtree(best_folder)
+                copytree(args.dest / f"iter{e:03d}", Path(best_folder))
 
             torch.save(net, args.dest / "bestmodel.pkl")
             torch.save(net.state_dict(), args.dest / "bestweights.pt")
@@ -269,6 +270,7 @@ def main():
 
     # Optimize snellius batch job
     parser.add_argument('--scratch', action='store_true', help="Use the scratch folder of snellius")
+    parser.add_argument('--dry_run', action='store_true', help="Disable saving the image validation results on every epoch")
 
     # Arguments for more flexibility of the run
     parser.add_argument('--remove_unannotated', action='store_true', help="Remove the unannotated images")

--- a/main.py
+++ b/main.py
@@ -79,7 +79,7 @@ def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, torch.optim.lr_schedu
     # lr = 0.0005 # Initial LR for ENet
     lr = args.lr
     optimizer = torch.optim.AdamW(net.parameters(), lr=lr, betas=(0.9, 0.999))
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=args.lr_scheduler_T0, T_mult=args.lr_scheduler_Tmult, eta_min=1e-7)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=args.lr_scheduler_T0, T_mult=args.lr_scheduler_Tmult)
 
     # Dataset part
     B: int = datasets_params[args.dataset]['B']
@@ -222,7 +222,7 @@ def runTraining(args):
         before_lr = optimizer.param_groups[0]['lr']
         scheduler.step()
         after_lr = optimizer.param_groups[0]['lr']
-        print("Epoch %d: AdamW lr %.4f -> %.4f" % (e, before_lr, after_lr))
+        print("Epoch %d: AdamW lr %.3E -> %.3E" % (e, before_lr, after_lr))
 
         metrics = utils.save_loss_and_metrics(K, e, args.dest,
                                               loss=[log_loss_tra, log_loss_val],
@@ -294,7 +294,7 @@ def main():
     parser.add_argument('--unfreeze_enc_last_n_layers', type=int, default=0, help="Train the last n layers of the encoder")
 
     args = parser.parse_args()
-    run_name = utils.get_run_name(args)
+    run_name = utils.get_run_name(args, parser)
     args.dest = args.dest / run_name
 
     # Added since for python 3.8+, OS X multiprocessing starts processes with spawn instead of fork

--- a/main.py
+++ b/main.py
@@ -65,7 +65,8 @@ datasets_params["TOY2"] = {'K': 2, 'net': shallowCNN, 'B': 2}
 datasets_params["SEGTHOR"] = {'K': 5, 'net': ENet, 'B': 8}
 
 
-def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, torch.optim.lr_scheduler.LRScheduler, Any, DataLoader, DataLoader, int]:
+# def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, torch.optim.lr_scheduler.LRScheduler, Any, DataLoader, DataLoader, int]:
+def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, Any, DataLoader, DataLoader, int]:
     # Networks and scheduler
     gpu: bool = args.gpu and torch.cuda.is_available()
     device = torch.device("cuda") if gpu else torch.device("cpu")
@@ -79,7 +80,7 @@ def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, torch.optim.lr_schedu
     # lr = 0.0005 # Initial LR for ENet
     lr = args.lr
     optimizer = torch.optim.AdamW(net.parameters(), lr=lr, betas=(0.9, 0.999), weight_decay=args.lr_weight_decay)
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=args.lr_scheduler_T0, T_mult=args.lr_scheduler_Tmult)
+    # scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=args.lr_scheduler_T0, T_mult=args.lr_scheduler_Tmult)
 
     # Dataset part
     B: int = datasets_params[args.dataset]['B']
@@ -132,14 +133,16 @@ def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, torch.optim.lr_schedu
 
     args.dest.mkdir(parents=True, exist_ok=True)
 
-    return net, optimizer, scheduler, device, train_loader, val_loader, K
+    # return net, optimizer, scheduler, device, train_loader, val_loader, K
+    return net, optimizer, device, train_loader, val_loader, K
 
 
 def runTraining(args):
 
     start = time.time()
     print(f">>> Setting up to train on {args.dataset} with {args.model}")
-    net, optimizer, scheduler, device, train_loader, val_loader, K = setup(args)
+    # net, optimizer, scheduler, device, train_loader, val_loader, K = setup(args)
+    net, optimizer, device, train_loader, val_loader, K = setup(args)
 
     loss_fn = create_loss_fn(args, K)
 
@@ -220,7 +223,7 @@ def runTraining(args):
 
         # Apply LR scheduler
         before_lr = optimizer.param_groups[0]['lr']
-        scheduler.step()
+        # scheduler.step()
         after_lr = optimizer.param_groups[0]['lr']
         print("Epoch %d: AdamW lr %.3E -> %.3E" % (e, before_lr, after_lr))
 

--- a/main.py
+++ b/main.py
@@ -259,13 +259,13 @@ def main():
     parser.add_argument('--debug', action='store_true',
                         help="Keep only a fraction (10 samples) of the datasets, "
                              "to test the logic around epochs and logging easily.")
-    
+
+    parser.add_argument('--lr', type=float, default=0.0005, help="Learning rate")
+    parser.add_argument('--dropoutRate', type=float, default=0.1, help="Dropout rate for the ENet model")
     parser.add_argument('--alpha', type=float, default=0.5, help="Alpha parameter for loss functions")
     parser.add_argument('--beta', type=float, default=0.5, help="Beta parameter for loss functions")
     parser.add_argument('--focal_alpha', type=float, default=0.25, help="Alpha parameter for Focal Loss")
     parser.add_argument('--focal_gamma', type=float, default=2.0, help="Gamma parameter for Focal Loss")
-    parser.add_argument('--lr', type=float, default=0.0005, help="Learning rate")
-    parser.add_argument('--dropoutRate', type=float, default=0.1, help="Dropout rate for the ENet model")
 
     # Optimize snellius batch job
     parser.add_argument('--scratch', action='store_true', help="Use the scratch folder of snellius")
@@ -277,9 +277,15 @@ def main():
     parser.add_argument('--run_prefix', type=str, default='', help='Name to prepend to the run name')
     parser.add_argument('--run_group', type=str, default=None, help='Your name so that the run can be grouped by it')
 
+    # Arguments for running with different backbones
+    parser.add_argument('--encoder_name', type=str, default='resnet18', choices=['resnet18', 'resnet34', 'resnet50', 'resnet101', 'resnet152'])
+    parser.add_argument('--unfreeze_enc_last_n_layers', type=int, default=0, help="Train the last n layers of the encoder")
+
     args = parser.parse_args()
     prefix = args.run_prefix + '_' if args.run_prefix else ''
-    run_name = f'{prefix}lr({"{:.0E}".format(args.lr)})_{args.loss}_{args.model}'
+    lr = f'lr({"{:.0E}".format(args.lr)})_' if args.lr != 0.0005 else ''
+    unfreeze_num_layers = f'(unfreeze-{args.unfreeze_enc_last_n_layers})' if args.unfreeze_enc_last_n_layers != 0 else ''
+    run_name = f'{prefix}{lr}{args.loss}_{args.model}_{args.encoder_name}{unfreeze_num_layers}'
     run_name = 'DEBUG_' + run_name if args.debug else run_name
     args.dest = args.dest / run_name
 

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ from torch import nn, Tensor
 from torchvision import transforms
 from torch.utils.data import DataLoader
 
-from models import UNet
+from models import *
 import utils
 from dataset import SliceDataset
 from ShallowNet import shallowCNN
@@ -268,11 +268,11 @@ def main():
                         help="Keep only a fraction (10 samples) of the datasets, "
                              "to test the logic around epochs and logging easily.")
 
+    parser.add_argument('--dropoutRate', type=float, default=0.2, help="Dropout rate for the ENet model")
     parser.add_argument('--lr', type=float, default=0.0005, help="Learning rate")
     parser.add_argument('--lr_scheduler_T0', type=int, default=10, help="T0 for the LR scheduler")
     parser.add_argument('--lr_scheduler_Tmult', type=int, default=2, help="Tmult for the LR scheduler")
 
-    parser.add_argument('--dropoutRate', type=float, default=0.2, help="Dropout rate for the ENet model")
     parser.add_argument('--alpha', type=float, default=0.5, help="Alpha parameter for loss functions")
     parser.add_argument('--beta', type=float, default=0.5, help="Beta parameter for loss functions")
     parser.add_argument('--focal_alpha', type=float, default=0.25, help="Alpha parameter for Focal Loss")
@@ -285,13 +285,13 @@ def main():
     # Arguments for more flexibility of the run
     parser.add_argument('--remove_unannotated', action='store_true', help="Remove the unannotated images")
     parser.add_argument('--loss', default='CrossEntropy', choices=['CrossEntropy', 'Dice', 'FocalLoss', 'CombinedLoss', 'FocalDiceLoss', 'TverskyLoss'])
-    parser.add_argument('--model', type=str, default='ENet', choices=['ENet', 'shallowCNN', 'UNet'])
+    parser.add_argument('--model', type=str, default='ENet', choices=['ENet', 'shallowCNN', 'UNet', 'UNetPlusPlus', 'DeepLabV3Plus'])
     parser.add_argument('--run_prefix', type=str, default='', help='Name to prepend to the run name')
     parser.add_argument('--run_group', type=str, default=None, help='Your name so that the run can be grouped by it')
 
     # Arguments for running with different backbones
     parser.add_argument('--encoder_name', type=str, default='resnet18', choices=['resnet18', 'resnet34', 'resnet50', 'resnet101', 'resnet152'])
-    parser.add_argument('--unfreeze_enc_last_n_layers', type=int, default=0, help="Train the last n layers of the encoder")
+    parser.add_argument('--unfreeze_enc_last_n_layers', type=int, default=1, help="Train the last n layers of the encoder")
 
     args = parser.parse_args()
     run_name = utils.get_run_name(args, parser)

--- a/main.py
+++ b/main.py
@@ -118,7 +118,8 @@ def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, Any, DataLoader, Data
     train_loader = DataLoader(train_set,
                               batch_size=B,
                               num_workers=args.num_workers,
-                              shuffle=True)
+                              shuffle=True,
+                              worker_init_fn=utils.seed_worker)
 
     val_set = SliceDataset('val',
                            root_dir,
@@ -139,6 +140,7 @@ def setup(args) -> tuple[nn.Module, torch.optim.Optimizer, Any, DataLoader, Data
 
 def runTraining(args):
 
+    utils.seed_everything(args)
     start = time.time()
     print(f">>> Setting up to train on {args.dataset} with {args.model}")
     # net, optimizer, scheduler, device, train_loader, val_loader, K = setup(args)
@@ -261,9 +263,9 @@ def main():
     parser.add_argument('--epochs', default=200, type=int)
     parser.add_argument('--dataset', default='SEGTHOR', choices=datasets_params.keys())
     parser.add_argument('--mode', default='full', choices=['partial', 'full'])
-    parser.add_argument('--args', default='')
     parser.add_argument('--dest', type=Path, required=True,
                         help="Destination directory to save the results (predictions and weights).")
+    parser.add_argument('--seed', default=42, type=int, help='Random seed to use for reproducibility of the experiments')
 
     parser.add_argument('--num_workers', type=int, default=5)
     parser.add_argument('--gpu', action='store_true')

--- a/main.py
+++ b/main.py
@@ -294,11 +294,7 @@ def main():
     parser.add_argument('--unfreeze_enc_last_n_layers', type=int, default=0, help="Train the last n layers of the encoder")
 
     args = parser.parse_args()
-    prefix = args.run_prefix + '_' if args.run_prefix else ''
-    lr = f'lr({"{:.0E}".format(args.lr)})_' if args.lr != 0.0005 else ''
-    unfreeze_num_layers = f'(unfreeze-{args.unfreeze_enc_last_n_layers})' if args.unfreeze_enc_last_n_layers != 0 else ''
-    run_name = f'{prefix}{lr}{args.loss}_{args.model}_{args.encoder_name}{unfreeze_num_layers}'
-    run_name = 'DEBUG_' + run_name if args.debug else run_name
+    run_name = utils.get_run_name(args)
     args.dest = args.dest / run_name
 
     # Added since for python 3.8+, OS X multiprocessing starts processes with spawn instead of fork

--- a/models.py
+++ b/models.py
@@ -11,8 +11,19 @@ class UNet(smp.Unet):
             in_channels=in_channels,
             classes=out_channels
         )
-        for param in self.encoder.parameters():
-            param.requires_grad = False
+
+        # Freeze all the layers of the encoder except the last n
+        unfreeze_enc_last_n_layers = kwargs['unfreeze_enc_last_n_layers']
+        enc_num_layers = 0
+        for _ in self.encoder.children():
+            enc_num_layers += 1
+        freeze_first_n_layers = enc_num_layers - unfreeze_enc_last_n_layers
+        for layer_num, layer in enumerate(self.encoder.children()):
+            if layer_num < freeze_first_n_layers:
+                for param in layer.parameters():
+                    param.requires_grad = False
+        print(f"> Initialized encoder {encoder_name} with first {freeze_first_n_layers}/{enc_num_layers} layers frozen")
+
 
     def init_weights(self):
         pass

--- a/models.py
+++ b/models.py
@@ -1,30 +1,61 @@
 import segmentation_models_pytorch as smp
+from torch import nn
 
 
-class UNet(smp.Unet):
-    def __init__(self, in_channels, out_channels, **kwargs):
-        encoder_name = kwargs['encoder_name'] if "encoder_name" in kwargs else 'resnet18'
-        encoder_weights = kwargs['encoder_weights'] if "encoder_weights" in kwargs else 'imagenet'
-        super().__init__(
-            encoder_name=encoder_name,
-            encoder_weights=encoder_weights,
-            in_channels=in_channels,
-            classes=out_channels
-        )
+class SegmentationModelBase:
 
-        # Freeze all the layers of the encoder except the last n
-        unfreeze_enc_last_n_layers = kwargs['unfreeze_enc_last_n_layers']
+    def initialize_base(self, kwargs):
+        self.encoder_name = kwargs['encoder_name']
+        self.encoder_weights = 'imagenet'
+        self.unfreeze_enc_last_n_layers = kwargs['unfreeze_enc_last_n_layers'] # How many of the last enc layers are unfrozen
+
+    # Freeze all the layers of the encoder except the last n
+    def freeze_encoder_layers(self):
         enc_num_layers = 0
         for _ in self.encoder.children():
             enc_num_layers += 1
-        freeze_first_n_layers = enc_num_layers - unfreeze_enc_last_n_layers
+        freeze_first_n_layers = enc_num_layers - self.unfreeze_enc_last_n_layers
         for layer_num, layer in enumerate(self.encoder.children()):
             if layer_num < freeze_first_n_layers:
                 for param in layer.parameters():
                     param.requires_grad = False
-        print(f"> Initialized encoder {encoder_name} with first {freeze_first_n_layers}/{enc_num_layers} layers frozen")
-
+        print(f"> Initialized encoder {self.encoder_name} with first {freeze_first_n_layers}/{enc_num_layers} layers frozen")
 
     def init_weights(self):
         pass
 
+
+class UNet(smp.Unet, SegmentationModelBase):
+    def __init__(self, in_channels, out_channels, **kwargs):
+        self.initialize_base(kwargs)
+        super().__init__(
+            encoder_name=self.encoder_name,
+            encoder_weights=self.encoder_weights,
+            in_channels=in_channels,
+            classes=out_channels
+        )
+        self.freeze_encoder_layers()
+
+
+class UNetPlusPlus(smp.UnetPlusPlus, SegmentationModelBase):
+    def __init__(self, in_channels, out_channels, **kwargs):
+        self.initialize_base(kwargs)
+        super().__init__(
+            encoder_name=self.encoder_name,
+            encoder_weights=self.encoder_weights,
+            in_channels=in_channels,
+            classes=out_channels
+        )
+        self.freeze_encoder_layers()
+
+
+class DeepLabV3Plus(smp.DeepLabV3Plus, SegmentationModelBase):
+    def __init__(self, in_channels, out_channels, **kwargs):
+        self.initialize_base(kwargs)
+        super().__init__(
+            encoder_name=self.encoder_name,
+            encoder_weights=self.encoder_weights,
+            in_channels=in_channels,
+            classes=out_channels
+        )
+        self.freeze_encoder_layers()

--- a/models.py
+++ b/models.py
@@ -1,0 +1,19 @@
+import segmentation_models_pytorch as smp
+
+
+class UNet(smp.Unet):
+    def __init__(self, in_channels, out_channels, **kwargs):
+        encoder_name = kwargs['encoder_name'] if "encoder_name" in kwargs else 'resnet18'
+        encoder_weights = kwargs['encoder_weights'] if "encoder_weights" in kwargs else 'imagenet'
+        super().__init__(
+            encoder_name=encoder_name,
+            encoder_weights=encoder_weights,
+            in_channels=in_channels,
+            classes=out_channels
+        )
+        for param in self.encoder.parameters():
+            param.requires_grad = False
+
+    def init_weights(self):
+        pass
+

--- a/utils.py
+++ b/utils.py
@@ -216,9 +216,6 @@ def save_loss_and_metrics(K: int, e: int, dest: Path,
 def get_run_name(args: Namespace, parser: argparse.ArgumentParser) -> str:
     prefix = args.run_prefix + '_' if args.run_prefix else ''
     lr = f'lr({"{:.0E}".format(args.lr)})_' if args.lr != parser.get_default('lr') else ''
-    if (args.lr_scheduler_T0 != parser.get_default('lr_scheduler_T0')
-            or args.lr_scheduler_Tmult != parser.get_default('lr_scheduler_Tmult')):
-        lr += f'LR-T0({args.lr_scheduler_T0})Tmult({args.lr_scheduler_Tmult})_'
     lr += f'LR-WD({args.lr_weight_decay})_' if args.lr_weight_decay != parser.get_default('lr_weight_decay') else ''
     dropout = f'dropout({args.dropoutRate})' if args.dropoutRate != parser.get_default('dropoutRate') else ''
     encoder_name = ''

--- a/utils.py
+++ b/utils.py
@@ -218,7 +218,7 @@ def get_run_name(args: Namespace, parser: argparse.ArgumentParser) -> str:
     if (args.lr_scheduler_T0 != parser.get_default('lr_scheduler_T0')
             or args.lr_scheduler_Tmult != parser.get_default('lr_scheduler_Tmult')):
         lr += f'LR-T0({args.lr_scheduler_T0})Tmult({args.lr_scheduler_Tmult})_'
-    lr += f'WD({args.weight_decay})_' if args.weight_decay != parser.get_default('weight_decay') else ''
+    lr += f'LR-WD({args.lr_weight_decay})_' if args.lr_weight_decay != parser.get_default('lr_weight_decay') else ''
     dropout = f'dropout({args.dropoutRate})' if args.dropoutRate != parser.get_default('dropoutRate') else ''
     encoder_name = ''
     if args.model != 'ENet':

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+from argparse import Namespace
 # MIT License
 
 # Copyright (c) 2024 Hoel Kervadec
@@ -209,3 +209,18 @@ def save_loss_and_metrics(K: int, e: int, dest: Path,
         metrics[f"train/dice-{k}"] = dice[0][e, :, k].mean().item()
         metrics[f"valid/dice-{k}"] = dice[1][e, :, k].mean().item()
     return metrics
+
+
+def get_run_name(args: Namespace) -> str:
+    prefix = args.run_prefix + '_' if args.run_prefix else ''
+    lr = f'lr({"{:.0E}".format(args.lr)})_' if args.lr != 0.0005 else ''
+    lr = lr + f'LR-T0({args.lr_scheduler_T0})Tmult({args.lr_scheduler_Tmult})'
+    dropout = f'dropout({args.dropoutRate})' if args.dropoutRate != 0.2 else ''
+    encoder_name = ''
+    unfreeze_num_layers = ''
+    if args.model != 'ENet':
+        encoder_name = f'_{args.encoder_name}'
+        unfreeze_num_layers = f'(unfreeze-{args.unfreeze_enc_last_n_layers})' if args.unfreeze_enc_last_n_layers != 0 else ''
+    run_name = f'{prefix}{dropout}{lr}{args.loss}_{args.model}{encoder_name}{unfreeze_num_layers}'
+    run_name = 'DEBUG_' + run_name if args.debug else run_name
+    return run_name

--- a/utils.py
+++ b/utils.py
@@ -232,6 +232,8 @@ def get_run_name(args: Namespace, parser: argparse.ArgumentParser) -> str:
 
 
 def seed_everything(args) -> None:
+    import os
+
     seed = args.seed
     print(f"> Using seed: {seed}")
     # Seed python
@@ -245,6 +247,8 @@ def seed_everything(args) -> None:
     if args.gpu:
         torch.use_deterministic_algorithms(True)
     torch.backends.cudnn.benchmark = False
+    # For the cuBLAS API of the CUDA implementation
+    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
 
 
 def seed_worker(worker_id):

--- a/utils.py
+++ b/utils.py
@@ -231,6 +231,7 @@ def get_run_name(args: Namespace, parser: argparse.ArgumentParser) -> str:
     return run_name
 
 
+# Using the suggestions from https://pytorch.org/docs/stable/notes/randomness.html
 def seed_everything(args) -> None:
     import os
 
@@ -243,9 +244,8 @@ def seed_everything(args) -> None:
     # Seed torch
     torch.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
-    # There are some operations which do not have deterministic equivalent on CPU (like max_unpool2d)
-    if args.gpu:
-        torch.use_deterministic_algorithms(True)
+    # Cannot set this since there are some operations which do not have deterministic equivalent (like max_unpool2d)
+    # torch.use_deterministic_algorithms(True)
     torch.backends.cudnn.benchmark = False
     # For the cuBLAS API of the CUDA implementation
     os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 from argparse import Namespace
 # MIT License
 
@@ -211,16 +212,18 @@ def save_loss_and_metrics(K: int, e: int, dest: Path,
     return metrics
 
 
-def get_run_name(args: Namespace) -> str:
+def get_run_name(args: Namespace, parser: argparse.ArgumentParser) -> str:
     prefix = args.run_prefix + '_' if args.run_prefix else ''
-    lr = f'lr({"{:.0E}".format(args.lr)})_' if args.lr != 0.0005 else ''
-    lr = lr + f'LR-T0({args.lr_scheduler_T0})Tmult({args.lr_scheduler_Tmult})'
-    dropout = f'dropout({args.dropoutRate})' if args.dropoutRate != 0.2 else ''
+    lr = f'lr({"{:.0E}".format(args.lr)})_' if args.lr != parser.get_default('lr') else ''
+    if (args.lr_scheduler_T0 != parser.get_default('lr_scheduler_T0')
+            or args.lr_scheduler_Tmult != parser.get_default('lr_scheduler_Tmult')):
+        lr += f'LR-T0({args.lr_scheduler_T0})Tmult({args.lr_scheduler_Tmult})'
+    dropout = f'dropout({args.dropoutRate})' if args.dropoutRate != parser.get_default('dropoutRate') else ''
     encoder_name = ''
-    unfreeze_num_layers = ''
     if args.model != 'ENet':
         encoder_name = f'_{args.encoder_name}'
-        unfreeze_num_layers = f'(unfreeze-{args.unfreeze_enc_last_n_layers})' if args.unfreeze_enc_last_n_layers != 0 else ''
-    run_name = f'{prefix}{dropout}{lr}{args.loss}_{args.model}{encoder_name}{unfreeze_num_layers}'
+        if args.unfreeze_enc_last_n_layers != parser.get_default('unfreeze_enc_last_n_layers'):
+            encoder_name += f'(unfreeze-{args.unfreeze_enc_last_n_layers})'
+    run_name = f'{prefix}{dropout}{lr}{args.loss}_{args.model}{encoder_name}'
     run_name = 'DEBUG_' + run_name if args.debug else run_name
     return run_name

--- a/utils.py
+++ b/utils.py
@@ -190,7 +190,9 @@ def prepare_wandb_login():
 
 # K - num of classes, e - epoch num
 # Loss and every metric are an array of [train_result, valid_result]
-def save_loss_and_metrics(K: int, e: int, dest: Path, loss: [Tensor, Tensor], dice: [Tensor, Tensor]) -> dict:
+def save_loss_and_metrics(K: int, e: int, dest: Path,
+                          loss: [Tensor, Tensor],
+                          dice: [Tensor, Tensor]) -> dict:
     # Save and log metrics and losses
     # I save it at each epochs, in case the code crashes or I decide to stop it early
     np.save(dest / "loss_tra.npy", loss[0])

--- a/utils.py
+++ b/utils.py
@@ -217,7 +217,8 @@ def get_run_name(args: Namespace, parser: argparse.ArgumentParser) -> str:
     lr = f'lr({"{:.0E}".format(args.lr)})_' if args.lr != parser.get_default('lr') else ''
     if (args.lr_scheduler_T0 != parser.get_default('lr_scheduler_T0')
             or args.lr_scheduler_Tmult != parser.get_default('lr_scheduler_Tmult')):
-        lr += f'LR-T0({args.lr_scheduler_T0})Tmult({args.lr_scheduler_Tmult})'
+        lr += f'LR-T0({args.lr_scheduler_T0})Tmult({args.lr_scheduler_Tmult})_'
+    lr += f'WD({args.weight_decay})_' if args.weight_decay != parser.get_default('weight_decay') else ''
     dropout = f'dropout({args.dropoutRate})' if args.dropoutRate != parser.get_default('dropoutRate') else ''
     encoder_name = ''
     if args.model != 'ENet':


### PR DESCRIPTION
Using the [segmentation-models-pytorch](https://smp.readthedocs.io/en/latest/index.html) library, the following models were implemented:
- UNet
- UnetPlusPlus
- DeepLabV3Plus

Each model comes with various backbones (resnet18, resnet34, etc.) pre-trained on the ImageNet dataset.
The backbones are fully frozen by default - added option to unfreeze the last `n` layers of it.

---

- Add seed configuration for the reproducibility of the experiments. Both the main libraries and the dataloaders are configured with the seed.
- Add LR scheduler - `OneCycleLR` and keep the same lr
- Add flag to disable saving the validation results at every iteration - was causing Snellius login node to go OoM after training a couple of models
- Change the save folder name to the `run_name`, so that multiple runs do not clash on the same write file access