### PR TITLE
Fix wandb disabled to skip login

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,8 +51,7 @@ from utils import (Dcm,
                    probs2class,
                    tqdm_,
                    dice_coef,
-                   save_images,
-                   prepare_wandb_login)
+                   save_images)
 
 from losses import create_loss_fn
 
@@ -278,7 +277,7 @@ def main():
 
     parser.add_argument('--dropoutRate', type=float, default=0.2, help="Dropout rate for the ENet model")
     parser.add_argument('--lr', type=float, default=0.0005, help="Learning rate")
-    parser.add_argument('--lr_weight_decay', type=float, default=0.01, help="Weight decay factor for the AdamW optimizer")
+    parser.add_argument('--lr_weight_decay', type=float, default=0.1, help="Weight decay factor for the AdamW optimizer")
     parser.add_argument('--enable_lr_scheduler', action='store_true')
 
     parser.add_argument('--alpha', type=float, default=0.5, help="Alpha parameter for loss functions")
@@ -289,6 +288,7 @@ def main():
     # Optimize snellius batch job
     parser.add_argument('--scratch', action='store_true', help="Use the scratch folder of snellius")
     parser.add_argument('--dry_run', action='store_true', help="Disable saving the image validation results on every epoch")
+    parser.add_argument('--disable_wandb', action='store_true', help="Disable the WandB logging")
 
     # Arguments for more flexibility of the run
     parser.add_argument('--remove_unannotated', action='store_true', help="Remove the unannotated images")
@@ -309,14 +309,13 @@ def main():
     # see https://github.com/pytest-dev/pytest-flask/issues/104
     multiprocessing.set_start_method("fork")
 
-    prepare_wandb_login()
-    wandb.login()
+    utils.wandb_login(args.disable_wandb)
     wandb.init(
         entity="ai_4_mi",
         project="SegTHOR",
         name=run_name,
         config=vars(args),
-        mode="disabled" if args.debug else "online",
+        mode="disabled" if args.disable_wandb else "online",
         group=args.run_group
     )
 

--- a/utils.py
+++ b/utils.py
@@ -29,6 +29,7 @@ from multiprocessing import Pool
 from contextlib import AbstractContextManager
 from typing import Callable, Iterable, List, Set, Tuple, TypeVar, cast
 
+import wandb
 import random
 import torch
 import numpy as np
@@ -181,13 +182,18 @@ def union(a: Tensor, b: Tensor) -> Tensor:
     return res
 
 
-def prepare_wandb_login():
-    try:
-        with open("wandb.password", "rt") as f:
-            pw = f.readline().strip()
-            os.environ["WANDB_API_KEY"] = pw
-    except FileNotFoundError:
-        print("!! File wandb.password was not found in the project root. WandB will be disabled during this run !!")
+def wandb_login(disable_wandb: bool):
+    if disable_wandb:
+        print("!! WandB disabled !!")
+        return
+    else:
+        try:
+            with open("wandb.password", "rt") as f:
+                pw = f.readline().strip()
+                os.environ["WANDB_API_KEY"] = pw
+                wandb.login()
+        except FileNotFoundError:
+            raise FileNotFoundError("File wandb.password was not found in the project root. Either add it or disable wandb by running --disable_wandb")
 
 
 # K - num of classes, e - epoch num


### PR DESCRIPTION
- Add separate flag to disable wandb logging during the run
   - If the flag is used, then login is skipped and the run will not crash
   - Else it will crash if login fails (missing password file)
- Fix default `lr_weight_decay=0.1` 